### PR TITLE
Bump dor-services to 5.x version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,17 @@
 source 'https://rubygems.org'
 
 gem 'addressable'
-gem 'dor-services', '~> 4.21.4'
+gem 'dor-services', '~> 5.2'
 gem 'lyber-core'
 gem 'robot-controller', '~> 2.0.3'  # requires Resque
-gem 'pry', '~> 0.10.0'          # for bin/console
-gem 'slop', '~> 3.5.0'          # for bin/run_robot
+gem 'pry', '~> 0.10.0'              # for bin/console
+gem 'slop', '~> 3.5.0'              # for bin/run_robot
 gem 'rake'
 gem 'yard'
 gem 'rspec'
 
 group :development, :test do
-  if File.exist?(mygems = File.join(ENV['HOME'],'.gemfile'))
+  if File.exist?(mygems = File.join(ENV['HOME'], '.gemfile'))
     instance_eval(File.read(mygems))
   end
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    active-fedora (5.7.1)
-      activeresource (>= 3.0.0)
+    active-fedora (6.7.3)
       activesupport (>= 3.0.0)
-      builder (~> 3.0.0)
       deprecation
       mediashelf-loggable
       nom-xml (>= 0.5.1)
-      om (~> 1.8.0)
+      om (~> 3.0.0)
       rdf
-      rdf-rdfxml (~> 0.3.8)
+      rdf-rdfxml (= 1.0.1)
       rsolr
-      rubydora (~> 1.6)
-      solrizer (~> 2.1)
+      rubydora (~> 1.6, >= 1.6.5)
     activemodel (3.2.22)
       activesupport (= 3.2.22)
       builder (~> 3.0.0)
-    activeresource (3.2.22)
-      activemodel (= 3.2.22)
-      activesupport (= 3.2.22)
     activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
@@ -76,11 +70,14 @@ GEM
     docopt (0.5.0)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services (4.21.4)
-      active-fedora (~> 5.7.1)
-      activesupport (~> 3.2, >= 3.2.18)
+    dor-rights-auth (1.0.2)
+      nokogiri
+    dor-services (5.2.0)
+      active-fedora (~> 6.0)
+      activesupport (>= 3.2.18)
       addressable (= 2.3.5)
       confstruct (~> 0.2.7)
+      dor-rights-auth (~> 1.0, >= 1.0.1)
       dor-workflow-service (~> 1.7, >= 1.7.1)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
@@ -90,21 +87,20 @@ GEM
       net-sftp (~> 2.1.2)
       net-ssh (~> 2.6.5)
       nokogiri (~> 1.6.0)
-      om (~> 1.8.0)
+      om (~> 3.0)
       osullivan (~> 0.0.3)
       progressbar (~> 0.21.0)
-      rdf (~> 1.0.9.0)
+      rdf (~> 1.1.7)
       rest-client (~> 1.7)
       retries
       rsolr-ext (~> 1.0.3)
       ruby-cache (~> 0.3.0)
       ruby-graphviz (~> 1.0.9)
       rubydora (~> 1.6.5)
-      solrizer (~> 2.0)
-      stanford-mods (~> 0.0.14)
+      solrizer (~> 3.0)
+      stanford-mods (~> 1.1)
       systemu (~> 2.6.0)
       uuidtools (~> 2.1.4)
-      validatable (~> 1.6.7)
     dor-workflow-service (1.7.6)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
@@ -126,6 +122,7 @@ GEM
     i18n (0.7.0)
     iso-639 (0.2.5)
     json (1.8.3)
+    link_header (0.0.8)
     lyber-core (3.3.0)
       dor-workflow-service (~> 1.7)
     lyber-utils (0.1.2)
@@ -165,16 +162,17 @@ GEM
       mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nom-xml (0.5.3)
+    nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    om (1.8.0)
+    om (3.0.7)
       activemodel
       activesupport
       deprecation
       mediashelf-loggable
       nokogiri (>= 1.4.2)
+      solrizer (~> 3.1.0)
     osullivan (0.0.3)
       activesupport (>= 3.2.18)
       faraday (~> 0.9.0)
@@ -189,14 +187,13 @@ GEM
       rack
     rainbow (2.0.0)
     rake (10.4.2)
-    rdf (1.0.9)
-      addressable (>= 2.3)
-    rdf-rdfxml (0.3.9)
-      rdf (>= 0.3.11)
-      rdf-xsd (>= 0.3.8)
-    rdf-xsd (1.0.2.1)
-      nokogiri (>= 1.5.0)
-      rdf (>= 0.3.4)
+    rdf (1.1.17.1)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-rdfxml (1.0.1)
+      rdf (>= 1.0)
+      rdf-xsd (>= 1.0)
+    rdf-xsd (1.1.5.1)
+      rdf (~> 1.1, >= 1.1.9, < 1.99)
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -216,7 +213,7 @@ GEM
       rake (~> 10.3)
       resque (~> 1.25.2)
       whenever (~> 0.9.2)
-    rsolr (1.0.12)
+    rsolr (1.0.13)
       builder (>= 2.1.2)
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
@@ -255,20 +252,19 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.5.0)
-    solrizer (2.2.0)
+    solrizer (3.1.1)
       activesupport
       daemons
       mediashelf-loggable (~> 0.4.7)
       nokogiri
-      om (>= 1.5.0)
       stomp
       xml-simple
     sshkit (1.3.0)
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (0.0.27)
-      mods
+    stanford-mods (1.3.3)
+      mods (~> 2.0.2)
     state_machine (1.2.0)
     stomp (1.3.4)
     systemu (2.6.5)
@@ -277,7 +273,7 @@ GEM
     thor (0.19.1)
     tilt (2.0.1)
     tins (1.6.0)
-    uber (0.0.14)
+    uber (0.0.15)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -300,7 +296,7 @@ DEPENDENCIES
   capistrano-bundler
   coveralls
   debugger
-  dor-services (~> 4.21.4)
+  dor-services (~> 5.2)
   holepicker (~> 0.3, >= 0.3.3)
   lyber-core
   lyberteam-capistrano-devel


### PR DESCRIPTION
All tests still pass.  Merge now, deploy when the reindexing is done and OPS is confident about any configuration changes.
